### PR TITLE
make git an explicit dependency

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -31,6 +31,7 @@ let
       carnix
       openssl.dev
       pkgconfig
+      git
     ] ++ (lib.optional stdenv.isDarwin pkgs.darwin.Security);
 
     HISTFILE = "${toString ./.}/.bash_hist";


### PR DESCRIPTION
My very old (10.10.x) builder tried to run a job, but failed with `error: unknown option `reference-if-able'` as it appears to have been using the system git which is also ancient. I'm still pending another job but i think this fixes it.